### PR TITLE
Fir filter

### DIFF
--- a/src/app/shared/bandpass-filter.ts
+++ b/src/app/shared/bandpass-filter.ts
@@ -1,28 +1,21 @@
 import * as Fili from 'fili';
 
 export class BandpassFilter {
-  readonly iirCalculator = new Fili.CalcCascades();
-  private readonly highpass: any;
-  private readonly lowpass: any;
+  readonly firCalculator = new Fili.FirCoeffs();
+  private readonly filter: any;
 
-  constructor(samplingFreq: number, lowFreq: number, highFreq: number, order = 4) {
-    const lowPassCoefficients = this.iirCalculator.lowpass({
-      order: 4,
-      characteristic: 'butterworth',
+  constructor(samplingFreq: number, lowFreq: number, highFreq: number) {
+    const Coefficients = this.firCalculator.bandpass({
+      order: 101,
       Fs: samplingFreq,
-      Fc: highFreq,
+      F2: lowFreq,
+      F1: highFreq,
     });
-    const highPassCoefficients = this.iirCalculator.highpass({
-      order: 4,
-      characteristic: 'butterworth',
-      Fs: samplingFreq,
-      Fc: lowFreq,
-    });
-    this.lowpass = new Fili.IirFilter(lowPassCoefficients);
-    this.highpass = new Fili.IirFilter(highPassCoefficients);
+
+    this.filter = new Fili.FirFilter(Coefficients);
   }
 
   next(value: number) {
-    return this.lowpass.singleStep(this.highpass.singleStep(value));
+    return this.filter.singleStep(value);
   }
 }


### PR DESCRIPTION
This is a PR to replace the IIR filter with a FIR filter.

the use of IIR filter distord signal (this can be easily seen on blinks) because of the non constant group delays. FIR generaly have a linear phase that does not distord the signal.

On the other hand , FIR are more computational.

here is a plot with new filter (and blinks)

![image](https://user-images.githubusercontent.com/2145718/32144819-bc290eac-bcbe-11e7-912e-2ffabea89b64.png)
